### PR TITLE
option to compile with -march=native to speed up CPU performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GPU=0
 CUDNN=0
 OPENCV=0
 OPENMP=0
+NATIVECPU=0
 DEBUG=0
 
 ARCH= -gencode arch=compute_30,code=sm_30 \
@@ -30,6 +31,10 @@ CFLAGS=-Wall -Wno-unknown-pragmas -Wfatal-errors -fPIC
 
 ifeq ($(OPENMP), 1) 
 CFLAGS+= -fopenmp
+endif
+
+ifeq ($(NATIVECPU), 1)
+CFLAGS+= -march=native
 endif
 
 ifeq ($(DEBUG), 1) 


### PR DESCRIPTION
On my laptop without GPU this gives me a significant improvement.
From about 26 seconds (9 with OpenMP) down to (still) 12 seconds (5 with OpenMP).

Intel(R) Core(TM) i5-6500T CPU @ 2.50GHz (4 cores)
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.5) 5.4.0 20160609

Deactivated by default to not break e.g. distributed compilation and cross compilation.