### PR TITLE
Support python 3

### DIFF
--- a/python/darknet.py
+++ b/python/darknet.py
@@ -131,9 +131,9 @@ if __name__ == "__main__":
     #meta = load_meta("cfg/imagenet1k.data")
     #r = classify(net, meta, im)
     #print r[:10]
-    net = load_net("cfg/tiny-yolo.cfg", "tiny-yolo.weights", 0)
-    meta = load_meta("cfg/coco.data")
-    r = detect(net, meta, "data/dog.jpg")
-    print r
+    net = load_net("cfg/tiny-yolo.cfg".encode("ascii"), "tiny-yolo.weights".encode("ascii"), 0)
+    meta = load_meta("cfg/coco.data".encode("ascii"))
+    r = detect(net, meta, "data/dog.jpg".encode("ascii"))
+    print(r)
     
 


### PR DESCRIPTION
By applying this commit, `darknet.py` is able to be imported and to be run on both 2 and 3 python versions.